### PR TITLE
#6 removed unused safe-eval dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The prototype isn't copied over.
 
 **Functions** are supported, they are stringified and will be eval-ed when called. 
 This lazy eval is important for performance.
-The eval happens via [safe-eval](https://www.npmjs.com/package/safe-eval)
+The eval happens via `eval()`
 Functions are stripped of comments and whitespace.
 
 > Obviously calling the function will only really work as expected if the functions were pure the begin with.

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "is-symbol": "^1.0.2",
     "isobject": "^3.0.1",
     "lodash.get": "^4.4.2",
-    "memoizerific": "^1.11.3",
-    "safe-eval": "^0.4.1"
+    "memoizerific": "^1.11.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3446,11 +3446,6 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-eval@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/safe-eval/-/safe-eval-0.4.1.tgz#e54ba5a1bbdec795d488f6c8765e0c2a78b4cdc0"
-  integrity sha512-wmiu4RSYVZ690RP1+cv/LxfPK1dIlEN35aW7iv4SMYdqDrHbkll4+NJcHmKm7PbCuI1df1otOcPwgcc2iFR85g==
-
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"


### PR DESCRIPTION
This PR solves this [issue](https://github.com/storybooks/telejson/issues/6)
`safe-eval` contains security vulnerability and is quarantined in corporate environments, which prevents people from installing telejson and @storybook/cli. 
`safe-eval` is not used in this project anymore, so it is safe to remove it.