### PR TITLE
deps(telejson): update to latest lodash, use tree-shakeable import fo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 dist
+.idea

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "is-regex": "^1.0.4",
     "is-symbol": "^1.0.2",
     "isobject": "^3.0.1",
-    "lodash.get": "^4.4.2",
+    "lodash": "^4.17.11",
     "memoizerific": "^1.11.3"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import isRegExp from 'is-regex';
 import isFunction from 'is-function';
 import isSymbol from 'is-symbol';
 import isObject from 'isobject';
-import get from 'lodash.get';
+import get from 'lodash/get';
 import memoize from 'memoizerific';
 
 const removeCodeComments = code => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2560,11 +2560,6 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"


### PR DESCRIPTION
## Issue:
Lodash modularised is OOOOoold. And has two CVEs listed against it. This prevents SB from being used by some developers with risk-averse corporate development environments.

## What I did
Updated lodash dependency to latest ^4.17.11
Touched up imports to use latest tree-shakeable lodash dependency format

## How to test
Tested using yarn test, no errors or warnings

